### PR TITLE
rewrite gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+public/uploads/*


### PR DESCRIPTION
#what
public/uploadsディレクトリを追加して、
GitHubに画像がコミットしないようにしました。

#why
ソースコードに関係がない為、不要